### PR TITLE
added install instructions

### DIFF
--- a/PythonAPI/README.md
+++ b/PythonAPI/README.md
@@ -1,0 +1,11 @@
+# Python Installation Instructions
+
+> [!WARNING]
+> Installation via `setup.py` is deprecated, and will not be possible in `pip 25.3` onwards. We should try to switch to `pyproject.toml`.
+
+Currently, it's necessary to manually install `setuptools`, `cython` and `numpy` before installing this package. You can use `pip --no-build-isolation` to ensure that the current environment is used for the build:
+
+```bash
+pip install cython numpy setuptools
+pip install --no-build-isolation "pycocotools @ git+https://github.com/MathiasEthon/cocoapi_rotated.git@master#subdirectory=PythonAPI"
+```


### PR DESCRIPTION
Adding install instructions, as I wasted some time figuring out how to install the package. But long-term, we should move away from `setup.py`